### PR TITLE
Stop stock update if MSI stock is null

### DIFF
--- a/src/Actions/UpdateMsiStock.php
+++ b/src/Actions/UpdateMsiStock.php
@@ -23,6 +23,10 @@ class UpdateMsiStock implements UpdatesStock
 
         $availableSources = $this->getAvailableSources();
 
+        if ($model->msi_stock === null) {
+            return;
+        }
+
         foreach ($model->msi_stock as $location => $quantity) {
             if (! in_array($location, $availableSources)) {
                 continue;

--- a/src/Contracts/RetrievesStockSkus.php
+++ b/src/Contracts/RetrievesStockSkus.php
@@ -11,5 +11,5 @@ interface RetrievesStockSkus
     public function retrieveAll(): Enumerable;
 
     /** @return Enumerable<int, string> */
-    public function retrieveUpdated(Carbon $from = null): Enumerable;
+    public function retrieveUpdated(?Carbon $from = null): Enumerable;
 }

--- a/src/Exceptions/UpdateException.php
+++ b/src/Exceptions/UpdateException.php
@@ -7,7 +7,7 @@ use Throwable;
 
 class UpdateException extends Exception
 {
-    public function __construct(string $sku, string $message, public array $payload = [], Throwable $previous = null)
+    public function __construct(string $sku, string $message, public array $payload = [], ?Throwable $previous = null)
     {
         parent::__construct("Failed to update $sku: $message", 0, $previous);
     }

--- a/src/Models/MagentoStock.php
+++ b/src/Models/MagentoStock.php
@@ -18,8 +18,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property bool $backorders
  * @property bool $magento_backorders_enabled
  * @property int $quantity
- * @property array $msi_stock
- * @property array $msi_status
+ * @property ?array $msi_stock
+ * @property ?array $msi_status
  * @property bool $retrieve
  * @property bool $update
  * @property ?Carbon $last_retrieved

--- a/src/Retriever/DummySkuRetriever.php
+++ b/src/Retriever/DummySkuRetriever.php
@@ -13,7 +13,7 @@ class DummySkuRetriever implements RetrievesStockSkus
         return collect(['::sku_1::', '::sku_2::']);
     }
 
-    public function retrieveUpdated(Carbon $from = null): Enumerable
+    public function retrieveUpdated(?Carbon $from = null): Enumerable
     {
         return collect(['::sku_1::']);
     }

--- a/tests/Actions/UpdateMsiStockTest.php
+++ b/tests/Actions/UpdateMsiStockTest.php
@@ -154,6 +154,11 @@ class UpdateMsiStockTest extends TestCase
         $action->update($stock);
 
         Event::assertNotDispatched(StockUpdatedEvent::class);
+
+        Http::assertNotSent(function (Request $request): bool {
+            return $request->method() === 'POST' &&
+                $request->url() === 'http://magento.test/rest/all/async/V1/inventory/source-items';
+        });
     }
 
     public function test_it_logs_error(): void

--- a/tests/Actions/UpdateMsiStockTest.php
+++ b/tests/Actions/UpdateMsiStockTest.php
@@ -135,6 +135,27 @@ class UpdateMsiStockTest extends TestCase
         Event::assertDispatched(StockUpdatedEvent::class);
     }
 
+    public function test_it_stops_when_stockdata_is_empty(): void
+    {
+        Http::fake([
+            '*/rest/all/V1/inventory/source-items*' => Http::response(),
+        ]);
+
+        /** @var UpdateMsiStock $action */
+        $action = app(UpdateMsiStock::class);
+
+        /** @var MagentoStock $stock */
+        $stock = MagentoStock::query()->first();
+
+        $stock->msi_stock = null;
+
+        $stock->msi_status = null;
+
+        $action->update($stock);
+
+        Event::assertNotDispatched(StockUpdatedEvent::class);
+    }
+
     public function test_it_logs_error(): void
     {
         Http::fake([


### PR DESCRIPTION
This fixes the following error which occurs if the stock data is empty in the `UpdateStockJob`.
`ErrorException: foreach() argument must be of type array|object, null given in`