### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Add the following commands to your scheduler.
        $schedule->command(\JustBetter\MagentoStock\Commands\Retrieval\RetrieveAllStockCommand::class)->dailyAt('05:00');
 
        // Retrieve modified stock every fifteen minutes, with a small overlap
-       $schedule->command(\JustBetter\MagentoStock\Commands\Retrieval\RetrieveAllStockCommand::class, ['from' => 'now -1 hour'])->everyFifteenMinutes();
+       $schedule->command(\JustBetter\MagentoStock\Commands\Retrieval\RetrieveAllStockCommand::class, ['now -1 hour'])->everyFifteenMinutes();
     }
 ```
 


### PR DESCRIPTION
Using a named argument causes the exception below:

Carbon\Exceptions\InvalidFormatException
Could not parse 'from=2025-03-14 09:30:00': Failed to parse time string (from=2025-03-14 09:30:00) at position 0 (f): The timezone could not be found in the database

Changed readme so the argument is not named.