### PR TITLE
Fix race condition when SaveStock and comparisons run concurrently

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
-  <testsuites>
-    <testsuite name="Tests">
-      <directory>./tests/*</directory>
-    </testsuite>
-  </testsuites>
-  <coverage/>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </source>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>./tests/*</directory>
+        </testsuite>
+    </testsuites>
+    <coverage/>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Actions/Comparison/CompareMsiStock.php
+++ b/src/Actions/Comparison/CompareMsiStock.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JustBetter\MagentoStock\Actions\Comparison;
 
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use JustBetter\MagentoClient\Client\Magento;
 use JustBetter\MagentoClient\Query\SearchCriteria;
 use JustBetter\MagentoProducts\Contracts\ChecksMagentoExistence;
@@ -51,8 +52,12 @@ class CompareMsiStock implements ComparesMsiStock
 
         event(new DifferenceDetectedEvent($stock));
 
-        $stock->update = true;
-        $stock->save();
+        DB::transaction(function () use ($stock): void {
+            /** @var Stock $locked */
+            $locked = Stock::query()->lockForUpdate()->findOrFail($stock->id);
+            $locked->update = true;
+            $locked->save();
+        });
     }
 
     protected function quantityEquals(Stock $localStock, Collection $msiStock): bool

--- a/src/Actions/Comparison/CompareSimpleStock.php
+++ b/src/Actions/Comparison/CompareSimpleStock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustBetter\MagentoStock\Actions\Comparison;
 
+use Illuminate\Support\Facades\DB;
 use JustBetter\MagentoClient\Client\Magento;
 use JustBetter\MagentoProducts\Contracts\ChecksMagentoExistence;
 use JustBetter\MagentoStock\Contracts\Comparison\ComparesSimpleStock;
@@ -42,8 +43,12 @@ class CompareSimpleStock implements ComparesSimpleStock
             ->performedOn($stock)
             ->log('Detected quantity difference, Magento: '.$stockItem['qty'].'. Should be: '.$stock->quantity);
 
-        $stock->update = true;
-        $stock->save();
+        DB::transaction(function () use ($stock): void {
+            /** @var Stock $locked */
+            $locked = Stock::query()->lockForUpdate()->findOrFail($stock->id);
+            $locked->update = true;
+            $locked->save();
+        });
 
         event(new DifferenceDetectedEvent($stock));
     }

--- a/src/Actions/Retrieval/SaveStock.php
+++ b/src/Actions/Retrieval/SaveStock.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JustBetter\MagentoStock\Actions\Retrieval;
 
+use Illuminate\Support\Facades\DB;
 use JustBetter\MagentoStock\Contracts\Retrieval\SavesStock;
 use JustBetter\MagentoStock\Data\StockData;
 use JustBetter\MagentoStock\Enums\Backorders;
@@ -13,27 +14,31 @@ class SaveStock implements SavesStock
 {
     public function save(StockData $stock, bool $forceUpdate): void
     {
-        /** @var Stock $model */
-        $model = Stock::query()->firstOrCreate([
-            'sku' => $stock['sku'],
-        ]);
+        DB::transaction(function () use ($stock, $forceUpdate): void {
+            /** @var Stock $model */
+            $model = Stock::query()
+                ->lockForUpdate()
+                ->firstOrCreate([
+                    'sku' => $stock['sku'],
+                ]);
 
-        $model->in_stock = $stock['in_stock'] ?? false;
-        $model->quantity = $stock['quantity'] ?? 0;
+            $model->in_stock = $stock['in_stock'] ?? false;
+            $model->quantity = $stock['quantity'] ?? 0;
 
-        $model->backorders = $stock['backorders'] ?? Backorders::NoBackorders;
+            $model->backorders = $stock['backorders'] ?? Backorders::NoBackorders;
 
-        $model->msi_stock = $stock['msi_quantity'];
-        $model->msi_status = $stock['msi_status'];
+            $model->msi_stock = $stock['msi_quantity'];
+            $model->msi_status = $stock['msi_status'];
 
-        $model->sync = true;
-        $model->retrieve = false;
-        $model->last_retrieved = now();
+            $model->sync = true;
+            $model->retrieve = false;
+            $model->last_retrieved = now();
 
-        $model->update = $forceUpdate || $model->checksum !== $stock->checksum() || $model->update;
-        $model->checksum = $stock->checksum();
+            $model->update = $forceUpdate || $model->checksum !== $stock->checksum() || $model->update;
+            $model->checksum = $stock->checksum();
 
-        $model->save();
+            $model->save();
+        });
     }
 
     public static function bind(): void


### PR DESCRIPTION
A race condition existed between SaveStock and CompareStock that could cause the update flag on a Stock model to be incorrectly reset to false.

Scenario:
1. CompareStock runs, detects a difference between local and Magento stock, sets update = true and saves.
2. SaveStock runs concurrently. It loaded the model before step 1 completed, so its in-memory copy still has update = false. It evaluates the checksum as unchanged (stock data hasn't changed), and saves — overwriting the update = true set by the comparison.
The result is that a detected stock discrepancy is silently lost and never pushed to Magento.

Solution:
Locking via DB::transaction and [lockForUpdate](https://laravel.com/docs/13.x/queries#pessimistic-locking).
Whichever job acquires the row lock first completes its read-write cycle in full before the other can proceed, making it impossible for either to overwrite the other's update flag.